### PR TITLE
Update quickstart.adoc - smallest pull request on the documentation ever XD

### DIFF
--- a/modules/ROOT/pages/quickstart.adoc
+++ b/modules/ROOT/pages/quickstart.adoc
@@ -43,6 +43,8 @@ Once you have:
 . installed the CLI 
 . configured the services 
 . installed Docker Desktop
+. Make sure Docker Desktop its running before the next operation
+
 
 you can install Nuvolaris and its services in Docker with just this command:
 


### PR DESCRIPTION
making sure docker desktop 
its installed and running before running the following command...


otherwise...

```
ERROR: failed to create cluster: failed to list nodes: command "docker ps -a --filter label=io.x-k8s.kind.cluster=nuvolaris --format '{{.Names}}'" failed with error: exit status 1
Command Output: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
error: task: Failed to run task "create": task: Failed to run task "cluster": exit status 1
error: task: Failed to run task "devcluster": exit status 1
```